### PR TITLE
[TT-9727] Fix deprecated error in PHP 8.1 regarding arrays

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -8,7 +8,7 @@
  * @copyright 2016, 2017 what3words Ltd
  * @link http://developer.what3words.com
  * @license MIT
- * @version 3.4.0
+ * @version 3.4.1
  * @package What3words\Geocoder
  */
 
@@ -17,7 +17,7 @@ namespace What3words\Geocoder;
 
 class Geocoder
 {
-  private $version = "3.4.0";  // if changing this, remember to change the comment block at the top, and match everything with the git tag
+  private $version = "3.4.1";  // if changing this, remember to change the comment block at the top, and match everything with the git tag
   private $apiKey = "";
   private $error = [];
   private $baseUrl = 'https://api.what3words.com/v3/';

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -7,7 +7,7 @@
  * @copyright 2016, 2017 what3words Ltd
  * @link http://developer.what3words.com
  * @license MIT
- * @version 3.4.0
+ * @version 3.4.1
  * @package What3words\Geocoder\Test
  */
 


### PR DESCRIPTION
This was a recent change in PHP8.1 with autovivification. The `Geocoder` class is still using `$error = false` to declare the array. Which will cause to display a deprecated warning message on PHP8.1:

```php
Deprecated: Automatic conversion of false to array is deprecated in /var/www/html/Geocoder.php on line XXX
```