### PR TITLE
[TT-9734] Allow use of restricted API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ use What3words\Geocoder\AutoSuggestOption;
 $api = new Geocoder("<Secret API Key>");
 ```
 
+#### Options
+
+You can also provide header values and referer (for restricted API keys).
+
+```php
+use What3words\Geocoder\Geocoder;
+use What3words\Geocoder\GeocoderOptions;
+
+$options = GeocoderOptions::referer("https://my.site.com/*")->headers(["X-Custom-Header: my.site.com"]);
+
+$api = new Geocoder("<Secret API Key>", $options);
+
+```
+
 ## Convert To Coordinates
 
 Convert a 3 word address to a position, expressed as coordinates of latitude and longitude.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "docs": "https://developer.what3words.com"
     },
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3"

--- a/composer.lock
+++ b/composer.lock
@@ -1312,7 +1312,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "platform-dev": []
 }

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -7,7 +7,7 @@
  * @copyright 2016, 2017 what3words Ltd
  * @link http://developer.what3words.com
  * @license MIT
- * @version 3.4.1
+ * @version 3.5.0
  * @package What3words\Geocoder\Test
  */
 


### PR DESCRIPTION
This PR adds a constructor parameter to the Geocoder class allowing users to pass in a referer, headers and host.